### PR TITLE
Fix null _sceneCamera dereference in NavigationZoom hooks (startup crash)

### DIFF
--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -108,18 +108,22 @@ void NavigationZoom_Update_Hook(auto original, NavigationZoom *_this)
         _this->_zoomDelta     = zoomDelta;
         _this->_lastZoomDelta = zoomDelta;
       }
-      auto worldPos      = GetMouseWorldPos(_this->_sceneCamera, &mousePos);
-      _this->_worldPoint = worldPos;
-      _this->ZoomCameraAtWorldPoint();
+      if (_this->_sceneCamera != nullptr) {
+        auto worldPos      = GetMouseWorldPos(_this->_sceneCamera, &mousePos);
+        _this->_worldPoint = worldPos;
+        _this->ZoomCameraAtWorldPoint();
+      }
     } else if (MapKey::IsPressed(GameFunction::ZoomOut) && !Key::IsInputFocused()) {
       vec3 mousePos;
       GetMousePosition(&mousePos);
       _this->_zoomLocation  = vec2{.x = mousePos.x, .y = mousePos.y};
       _this->_zoomDelta     = -1.0f * zoomDelta;
       _this->_lastZoomDelta = -1.0f * zoomDelta;
-      auto worldPos         = GetMouseWorldPos(_this->_sceneCamera, &mousePos);
-      _this->_worldPoint    = worldPos;
-      _this->ZoomCameraAtWorldPoint();
+      if (_this->_sceneCamera != nullptr) {
+        auto worldPos         = GetMouseWorldPos(_this->_sceneCamera, &mousePos);
+        _this->_worldPoint    = worldPos;
+        _this->ZoomCameraAtWorldPoint();
+      }
     }
   }
 
@@ -138,10 +142,14 @@ void NavigationZoom_SetViewParameters_Hook(auto original, NavigationZoom *_this,
     auto ratio                     = (Config::Get().zoom / radius);
     _this->_farRatioSystemNormal   = 0.55f * ratio;
     _this->_farRatioSystemExtended = 1 * ratio;
-    _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    if (_this->_sceneCamera != nullptr) {
+      _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    }
     original(_this, radius, depth);
-    _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
-    do_default_zoom                   = true;
+    if (_this->_sceneCamera != nullptr) {
+      _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    }
+    do_default_zoom = true;
   } else {
     original(_this, radius, depth);
   }
@@ -150,13 +158,17 @@ void NavigationZoom_SetViewParameters_Hook(auto original, NavigationZoom *_this,
 void NavigationZoom_SetDepth_Hook(auto original, NavigationZoom *_this, NodeDepth depth)
 {
   if (depth == NodeDepth::SolarSystem) {
-    auto ratio                        = (Config::Get().zoom / _this->_viewRadius);
-    _this->_farRatioSystemNormal      = 0.55f * ratio;
-    _this->_farRatioSystemExtended    = 1 * ratio;
-    _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    auto ratio                     = (Config::Get().zoom / _this->_viewRadius);
+    _this->_farRatioSystemNormal   = 0.55f * ratio;
+    _this->_farRatioSystemExtended = 1 * ratio;
+    if (_this->_sceneCamera != nullptr) {
+      _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    }
     original(_this, depth);
-    _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
-    do_default_zoom                   = true;
+    if (_this->_sceneCamera != nullptr) {
+      _this->_sceneCamera->farClipPlane = Config::Get().zoom * 3.75f;
+    }
+    do_default_zoom = true;
   } else {
     original(_this, depth);
   }


### PR DESCRIPTION
## Summary

On macOS, the game crashes at launch with `EXC_BAD_ACCESS (SIGSEGV)` — a byte read from address `0x0` — inside `libstfc-community-patch.dylib`. Reproduced on game versions **v1.000.48084** and **v1.000.48394**.

## Root Cause

During early app startup, Unity's `NSApplicationDidFinishLaunchingNotification` observer triggers a Unity engine tick before `_sceneCamera` is assigned on the `NavigationZoom` object. Three hooks dereference `_this->_sceneCamera` without a null check:

- `NavigationZoom_Update_Hook` — passes `_sceneCamera` to `GetMouseWorldPos`
- `NavigationZoom_SetViewParameters_Hook` — writes `_sceneCamera->farClipPlane`
- `NavigationZoom_SetDepth_Hook` — writes `_sceneCamera->farClipPlane`

**Crash stack:**
```
0  libstfc-community-patch.dylib  +2198804  ← NavigationZoom_Update_Hook
1  libstfc-community-patch.dylib  +1895460  ← hook trampoline
2  Assembly-CSharp                          ← NavigationZoom.Update()
```
ESR `0x92000006` = byte read Translation fault at `0x0`.

## Fix

Added `_sceneCamera != nullptr` guards before all three dereference sites. If the camera isn't ready yet the hook skips those operations and falls through to `original()` normally.

## Test Plan

- [ ] Install new DMG and confirm game launches without crash on macOS
- [ ] Verify zoom in/out, zoom presets, and default zoom still work correctly in a solar system view
- [ ] Confirm `farClipPlane` is still being applied when entering a solar system